### PR TITLE
Do not force ExDoc as a compile time dependency on users.

### DIFF
--- a/lib/mix/tasks/update_readme.ex
+++ b/lib/mix/tasks/update_readme.ex
@@ -25,11 +25,11 @@ defmodule Mix.Tasks.UpdateReadme do
     File.write!("README.md", result)
   end
 
-  def fn_docs(f = %ExDoc.FunctionNode{doc: nil}, result) do
+  def fn_docs(f = %{__struct__: ExDoc.FunctionNode, doc: nil}, result) do
     [ signature(f.signature) | result ]
   end
 
-  def fn_docs(f = %ExDoc.FunctionNode{}, result) do
+  def fn_docs(f = %{__struct__: ExDoc.FunctionNode}, result) do
     indented_doc =
       String.split(f.doc, "\n")
       |> Enum.map(&"  #{&1}")


### PR DESCRIPTION
Without this change, I am getting a compile error:

```
== Compilation error on file lib/mix/tasks/update_readme.ex ==
** (CompileError) lib/mix/tasks/update_readme.ex:28: ExDoc.FunctionNode.__struct__/0 is undefined, cannot expand struct ExDoc.FunctionNode
    (stdlib) lists.erl:1353: :lists.mapfoldl/3
```

While it is a bit ugly to pattern match on the `__struct__` key, it
allows us to pattern match on the struct without requiring its definition
to be present at compile time, so that users no longer need ex_doc.