### PR TITLE
Include right and left values when errors are re-thrown

### DIFF
--- a/lib/quixir/props.ex
+++ b/lib/quixir/props.ex
@@ -58,15 +58,18 @@ defmodule Quixir.Props do
               rescue e in [ExUnit.AssertionError] ->
                 false
               end
-          end
-          try do
-            Shrinker.shrink({shrinker, q_state, q_locals})
-          rescue qe in [Quixir.PropertyError] ->
-            raise(ExUnit.AssertionError, [
-                  message: "#{e.message}\n#{qe.message}",
-                  expr:    e.expr
-                ])
-          end
+            end
+
+            try do
+              Shrinker.shrink({shrinker, q_state, q_locals})
+            rescue qe in [Quixir.PropertyError] ->
+              raise(ExUnit.AssertionError, [
+                    message: "#{e.message}\n#{qe.message}",
+                    expr:    e.expr,
+                    left:    e.left,
+                    right:   e.right,
+                  ])
+            end
         end
 
         q_state


### PR DESCRIPTION
Having the right and left values allows you to easily see whats failed if you're doing a comparison. I've updated the assertion error to include the right and left values from the original assertion error.